### PR TITLE
docs: fix 'an type' to 'a type' in KUK0002.md

### DIFF
--- a/docs/wiki/KUK0002.md
+++ b/docs/wiki/KUK0002.md
@@ -8,7 +8,7 @@ KUK0002
 This rule detects cases where the file name and file type names (e.g. `class`, `interface`, `struct`, `enum`, etc.) mismatch.
 
 ## ❔ Why this is a problem
-Let's imagine you have an type in your database, say, `Customer`. Now you want to find this type in your code using a search engine. You type `Customer` and find nothing...
+Let's imagine you have a type in your database, say, `Customer`. Now you want to find this type in your code using a search engine. You type `Customer` and find nothing...
 After using a symbol or full-text search across the codebase, you realize that `Customer` has been renamed in the code (even though it was previously just `User`), but someone forgot to rename it in the file name. This isn't a critical issue, but it degrades navigability and makes code exploration less predictable, as the word `Customer` can appear not only in the class name but also in the names of variables, methods, and so on.
 
 ## ⚙️ Configuration


### PR DESCRIPTION
## Summary
Fixes a grammatical error in the KUK0002 wiki documentation.

## Related Issue
Fixes #41

## Changes
- Changed 'you have an type' to 'you have a type' in `docs/wiki/KUK0002.md`